### PR TITLE
update: v0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.direnv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes will be documented here in reverse chronological order the headers \<VERSION\> - <YY.MM.DD>.
 
+## 0.9.1 - 2026.05.06
+
+## Fix
+
+- Use `Table<'_>` and `TracebackTable<'_>` in return types for clearer lifetime annotations.
+
+### Update
+
+Bumped
+- libc 0.2.179 -> 0.2.186
+- libparasail-sys 0.2.0 -> 0.2.1
+- bitflags 2.10.0 -> 2.11.1
+
+
 ## 0.9.0 - 2026.01.04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cc"
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "libparasail-sys"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efca43b808a2d9db44a3292a4741f57597d5b11376a43b05563b709b1e646c7"
+checksum = "9d35f038ce0fcb67fefefc29843bfa43cae51e078dd3f276a791d8b3d96c7320"
 dependencies = [
  "bindgen",
  "cmake",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "parasail-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bitflags",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parasail-rs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Nicolas S. Buitrago <nsb5@rice.edu>"]
 description = "Rust bindings and wrapper for parasail, a SIMD C library for pairwise sequence alignment."
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/parasail-rs"
 
 [dependencies]
 derive_more = { version = "2.1.1", features = ["from"] }
-libc = "0.2.179"
-libparasail-sys = "0.2.0"
+libc = "0.2.186"
+libparasail-sys = "0.2.1"
 log = "0.4.29"
-bitflags = "2.10.0"
+bitflags = "2.11.1"

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
-        "revCount": 797896,
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "revCount": 992384,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.797896%2Brev-d89fc19e405cb2d55ce7cc114356846a0ee5e956/0196c1a7-7ad3-74a9-9d50-1b854aca6d6c/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.992384%2Brev-549bd84d6279f9852cae6225e372cc67fb91a4c1/019df915-70b5-73a2-a5a4-63c620b45d9f/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747017456,
-        "narHash": "sha256-C/U12fcO+HEF071b5mK65lt4XtAIZyJSSJAg9hdlvTk=",
+        "lastModified": 1778037418,
+        "narHash": "sha256-EZnAOkPgEeOO2rCRhwkTvesCq/E6dbsyxhMyaefgIWM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5b07506ae89b025b14de91f697eba23b48654c52",
+        "rev": "adf987c76af8d17b8256d23631bcf203f81e1a63",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.94.1"
 components = ["rust-src", "rustfmt"]
 profile = "default"

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -120,7 +120,7 @@ impl Alignment {
     /// println!("Final score: {}", table.last());
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn get_score_table(&self) -> Result<Table> {
+    pub fn get_score_table(&self) -> Result<Table<'_>> {
         if self.is_table() || self.is_stats_table() {
             unsafe {
                 let table_ptr = parasail_result_get_score_table(self.inner);
@@ -138,7 +138,7 @@ impl Alignment {
     }
 
     /// Get the matches table.
-    pub fn get_matches_table(&self) -> Result<Table> {
+    pub fn get_matches_table(&self) -> Result<Table<'_>> {
         if self.is_stats_table() {
             unsafe {
                 let table_ptr = parasail_result_get_matches_table(self.inner);
@@ -156,7 +156,7 @@ impl Alignment {
     }
 
     /// Get the similar table.
-    pub fn get_similar_table(&self) -> Result<Table> {
+    pub fn get_similar_table(&self) -> Result<Table<'_>> {
         if self.is_stats_table() {
             unsafe {
                 let table_ptr = parasail_result_get_similar_table(self.inner);
@@ -174,7 +174,7 @@ impl Alignment {
     }
 
     /// Get the length table.
-    pub fn get_length_table(&self) -> Result<Table> {
+    pub fn get_length_table(&self) -> Result<Table<'_>> {
         if self.is_stats_table() {
             unsafe {
                 let table_ptr = parasail_result_get_length_table(self.inner);
@@ -288,7 +288,7 @@ impl Alignment {
     }
 
     /// Get the trace table.
-    pub fn get_trace_table(&self) -> Result<TracebackTable> {
+    pub fn get_trace_table(&self) -> Result<TracebackTable<'_>> {
         if self.is_trace() {
             unsafe {
                 let table_ptr = parasail_result_get_trace_table(self.inner) as *const i8;


### PR DESCRIPTION
- Bumps libparasail-sys, libc, and bitflags dependencies
- Alignment methods that return tables use Table<_'> and TracebackTable<_'> for clearer lifetime annotations